### PR TITLE
Macos fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,31 +34,10 @@
         "type": "github"
       }
     },
-    "ocaml-overlays": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1752960999,
-        "narHash": "sha256-Xe3npyn5fue7L+llELVZxMSO1026eI5g6cl2Kwd/oUs=",
-        "owner": "nix-ocaml",
-        "repo": "nix-overlays",
-        "rev": "48fe3eafca6e289546861fb82dce42d4330ada15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-ocaml",
-        "repo": "nix-overlays",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "ocaml-overlays": "ocaml-overlays"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,16 +2,11 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    ocaml-overlays = {
-      url = "github:nix-ocaml/nix-overlays";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
-  outputs = { self, flake-utils, nixpkgs, ocaml-overlays }:
+  outputs = { self, flake-utils, nixpkgs }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = (import nixpkgs { inherit system; }).appendOverlays
-          [ ocaml-overlays.overlays.default ];
+        pkgs = (import nixpkgs { inherit system; });
 
         # Returns a set of dune packages with keys "dynamic" and "static" which
         # correspond to a dynamically-linked and statically-linked instance of


### PR DESCRIPTION
Fix build for macos by avoiding using the ocaml-overlays repo and instead defining a custom derivation for dune giving more control over how it's built.