### PR TITLE
Add posix sh env script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: test
+on: [push, pull_request]
+jobs:
+
+  shellcheck:
+    name: "Run shellcheck on the shell env script"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Install shellcheck"
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y shellcheck
+    - name: "Run shellcheck on the shell env script"
+      run: |
+        # exclude warning for sourcing missing external file
+        shellcheck extra/share/dune/env/env.sh extra/share/dune/env/env.bash

--- a/extra/share/dune/env/env.sh
+++ b/extra/share/dune/env/env.sh
@@ -1,27 +1,22 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 __dune_env() {
   if [ "$#" != "1" ]; then
     echo "__dune_env expected 1 argument, got $#"
     return
   fi
-  local ROOT="$1"
+  __dune_root="$1"
 
   # Add dune to PATH unless it's already present.
   # Affix colons on either side of $PATH to simplify matching (based on
   # rustup's env script).
   case :"$PATH": in
-    *:"$ROOT/bin":*)
+    *:"$__dune_root/bin":*)
       # Do nothing since the bin directory is already in PATH.
       ;;
     *)
       # Prepending path in case a system-installed dune needs to be overridden
-      export PATH="$ROOT/bin:$PATH"
+      export PATH="$__dune_root/bin:$PATH"
       ;;
   esac
-
-  # Load bash completions for dune.
-  # Suppress warning from shellcheck as it can't see the completion script.
-  # shellcheck disable=SC1091
-  . "$ROOT"/share/bash-completion/completions/dune
 }


### PR DESCRIPTION
This amounted taking the bash env script and removing its use of the `local` keyword and changing is extension to ".sh".

This allows the dune binary distro to be used on machines with minimal shells such as the ash shell in the default environment on alpine linux.

Also adds a test that runs shellcheck on env.sh to make sure it stays posix-compatible.